### PR TITLE
add pre-commit and set git-push to false on terraform-dos action

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,12 @@
+# Contributing
+
+Please first discuss the changes you would like to make to this repository by first opening an issue.
+
+## Documentation
+
+All CI tests on pull requests must be passing before being merged.
+Documentation is auto-generated via [terraform-docs](https://terraform-docs.io/).
+A github action will check that all README files are up to date via a [pre-commit](https://pre-commit.com/) hook in our [.pre-commit-config.yaml](../pre-commit-config.yaml).
+You will want to run this locally in order to get our CI test to pass.
+Be sure that you have both [pre-commit](https://pre-commit.com/#installation) and [terraform-docs](https://terraform-docs.io/user-guide/installation/) installed.
+Then before commiting changes to your branch run `pre-commit run -a` to update documentation.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,27 +32,15 @@ jobs:
       run: terraform fmt -write=false -recursive
 
   docs:
-    needs: validate
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
-      matrix:
-        include:
-          - working-dir: "."
-            recursive: true
-          - working-dir: "examples/opencbdc-tctl"
-            recursive: false
-
     steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
+    - uses: actions/checkout@v1
+    - name: Install pre-commit dependencies
+      shell: bash
+      run: |
+        pip install -q pre-commit
+        brew install terraform-docs
 
-    - name: Render terraform docs and push changes back to PR
-      uses: terraform-docs/gh-actions@main
-      with:
-        working-dir: ${{ matrix.working-dir }}
-        output-file: README.md
-        output-method: inject
-        git-push: true
-        recursive: ${{ matrix.recursive }}
+    - name: Execute pre-commit
+      shell: bash
+      run: pre-commit run --all-files --color always --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.72.1
+    hooks:
+      - id: terraform_docs
+        args:
+          - '--args=--lockfile=false'
+          - '--hook-config=--create-file-if-not-exist=true'
+          - '--hook-config=--add-to-existing-file=true'

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Specifically:
 | All Standard (A, C, D, H, I, M, R, T, Z) Spot Instance Requests | 32,000 | 32,000 | 32,000 |
 | Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances | 32,000 | 32,000 | 32,000 |
 
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
@@ -300,4 +300,4 @@ Specifically:
 | <a name="output_vpc_id_use1"></a> [vpc\_id\_use1](#output\_vpc\_id\_use1) | Id of VPC in us-east-1 region |
 | <a name="output_vpc_id_use2"></a> [vpc\_id\_use2](#output\_vpc\_id\_use2) | Id of VPC in us-east-2 region |
 | <a name="output_vpc_id_usw2"></a> [vpc\_id\_usw2](#output\_vpc\_id\_usw2) | Id of VPC in us-west-2 region |
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/opencbdc-tctl/README.md
+++ b/examples/opencbdc-tctl/README.md
@@ -20,7 +20,7 @@ Be sure to run `terraform destroy` when you don't need these resources.
 Terraform uses them to keep track of resources within your environment.
 Tampering them can put your enviornment in an inconsistent state.
 
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 No requirements.
@@ -71,4 +71,4 @@ No resources.
 | <a name="output_vpc_id_use1"></a> [vpc\_id\_use1](#output\_vpc\_id\_use1) | Id of VPC in us-east-1 region |
 | <a name="output_vpc_id_use2"></a> [vpc\_id\_use2](#output\_vpc\_id\_use2) | Id of VPC in us-east-2 region |
 | <a name="output_vpc_id_usw2"></a> [vpc\_id\_usw2](#output\_vpc\_id\_usw2) | Id of VPC in us-west-2 region |
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/bastion/README.md
+++ b/modules/bastion/README.md
@@ -1,4 +1,4 @@
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 No requirements.
@@ -49,4 +49,4 @@ No requirements.
 | Name | Description |
 |------|-------------|
 | <a name="output_bastion_enpoint"></a> [bastion\_enpoint](#output\_bastion\_enpoint) | The bastion endpoint where users can access via an ssh connection |
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/route53_dns/README.md
+++ b/modules/route53_dns/README.md
@@ -1,4 +1,4 @@
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 No requirements.
@@ -36,4 +36,4 @@ No modules.
 | <a name="output_cert_arn"></a> [cert\_arn](#output\_cert\_arn) | The ACM cert ARN |
 | <a name="output_hosted_zone_id"></a> [hosted\_zone\_id](#output\_hosted\_zone\_id) | Route53 hosted zone id of the base domain |
 | <a name="output_name_servers"></a> [name\_servers](#output\_name\_servers) | Name servers associated with Route53 base domain |
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/test-controller-agent/README.md
+++ b/modules/test-controller-agent/README.md
@@ -1,4 +1,4 @@
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 No requirements.
@@ -53,4 +53,4 @@ No requirements.
 ## Outputs
 
 No outputs.
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/test-controller-deploy/README.md
+++ b/modules/test-controller-deploy/README.md
@@ -1,4 +1,4 @@
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 No requirements.
@@ -62,4 +62,4 @@ No requirements.
 ## Outputs
 
 No outputs.
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/test-controller/README.md
+++ b/modules/test-controller/README.md
@@ -1,4 +1,4 @@
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 No requirements.
@@ -106,4 +106,4 @@ No requirements.
 | <a name="output_testruns_efs_ap_arn"></a> [testruns\_efs\_ap\_arn](#output\_testruns\_efs\_ap\_arn) | The EFS ARN for the testruns access point. |
 | <a name="output_testruns_efs_id"></a> [testruns\_efs\_id](#output\_testruns\_efs\_id) | The EFS ID for the testruns volume. |
 | <a name="output_ui_endpoint"></a> [ui\_endpoint](#output\_ui\_endpoint) | The test controller endpoint where users can connect to the UI |
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/uhs-seed-generator/README.md
+++ b/modules/uhs-seed-generator/README.md
@@ -1,4 +1,4 @@
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 No requirements.
@@ -58,4 +58,4 @@ No requirements.
 | <a name="output_job_definiton_arn"></a> [job\_definiton\_arn](#output\_job\_definiton\_arn) | Arn of the uhs\_seed\_generator job definition |
 | <a name="output_job_name"></a> [job\_name](#output\_job\_name) | Name of uhs seed generator job |
 | <a name="output_job_queue_arn"></a> [job\_queue\_arn](#output\_job\_queue\_arn) | Arn of the uhs\_seed\_generator job queue |
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/universe0-deploy/README.md
+++ b/modules/universe0-deploy/README.md
@@ -1,4 +1,4 @@
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 No requirements.
@@ -46,4 +46,4 @@ No modules.
 ## Outputs
 
 No outputs.
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -1,4 +1,4 @@
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 No requirements.
@@ -37,4 +37,4 @@ No requirements.
 | Name | Description |
 |------|-------------|
 | <a name="output_s3_interface_endpoint"></a> [s3\_interface\_endpoint](#output\_s3\_interface\_endpoint) | DNS must be specified in order to route traffic through to the s3 interface endpoint |
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vpc-peering-connection/README.md
+++ b/modules/vpc-peering-connection/README.md
@@ -1,4 +1,4 @@
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 No requirements.
@@ -41,4 +41,4 @@ No modules.
 ## Outputs
 
 No outputs.
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
The current terraform-docs Github action is broken for prs that come from forks. This is because Github actions is unable to clone/push to different repos in order to update documentation. This PR fixes the docs flow. A pre commit has been added to run terraform-docs. It will pass if all the README files are up to date and fail otherwise so no push back to the repo occurs. Instructions have been included on how to update the docs locally in order to get the docs to pass using the pre-commit.