### PR TITLE
Fix certbot lambda replacement bug

### DIFF
--- a/modules/test-controller/README.md
+++ b/modules/test-controller/README.md
@@ -13,7 +13,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_certbot_lambda"></a> [certbot\_lambda](#module\_certbot\_lambda) | terraform-aws-modules/lambda/aws | ~> 3.0.0 |
+| <a name="module_certbot_lambda"></a> [certbot\_lambda](#module\_certbot\_lambda) | terraform-aws-modules/lambda/aws | 3.3.1 |
 | <a name="module_certbot_security_group"></a> [certbot\_security\_group](#module\_certbot\_security\_group) | terraform-aws-modules/security-group/aws | 3.1.0 |
 | <a name="module_efs_security_group"></a> [efs\_security\_group](#module\_efs\_security\_group) | terraform-aws-modules/security-group/aws | 3.1.0 |
 | <a name="module_nlb"></a> [nlb](#module\_nlb) | terraform-aws-modules/alb/aws | 5.13.0 |

--- a/modules/test-controller/main.tf
+++ b/modules/test-controller/main.tf
@@ -289,7 +289,7 @@ resource "aws_ecs_task_definition" "task" {
         "name": "TRANSACTION_PROCESSOR_MAIN_BRANCH",
         "value" : "${var.transaction_processor_main_branch}"
       },
-      {   
+      {
         "name": "UHS_SEEDER_BATCH_JOB",
         "value": "${var.uhs_seed_generator_job_name}"
       }
@@ -648,7 +648,7 @@ resource "aws_efs_mount_target" "certs" {
 
 resource "aws_efs_mount_target" "testruns" {
   count = length(var.private_subnets)
-  
+
   file_system_id  = aws_efs_file_system.testruns.id
   subnet_id       = var.private_subnets[count.index]
   security_groups = [ module.efs_security_group.this_security_group_id ]
@@ -719,7 +719,7 @@ module "certbot_lambda" {
   count = var.create_certbot_lambda ? 1 : 0
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 3.0.0"
+  version = "3.3.1"
 
   function_name = "${local.name}-certbot-lambda"
   description   = "Certbot lambda"
@@ -729,7 +729,8 @@ module "certbot_lambda" {
 
   build_in_docker = true
 
-  source_path = "${path.module}/lambda/certbot"
+  source_path              = "${path.module}/lambda/certbot"
+  recreate_missing_package = false
 
   vpc_subnet_ids         = var.private_subnets
   vpc_security_group_ids = [ module.certbot_security_group[0].this_security_group_id ]


### PR DESCRIPTION
Currently there is an issue in CI/CD (Github Workflows) where the local zip archive containing code for the certbot lambda is recreated on every PR. This is because every workflow run starts with a clean environment.
