### PR TITLE
lambda in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Specifically:
 | <a name="input_fire_hose_buffering_interval"></a> [fire\_hose\_buffering\_interval](#input\_fire\_hose\_buffering\_interval) | Interval time between sending Fire Hoe buffer data to Open Search | `number` | `60` | no |
 | <a name="input_fire_hose_index_rotation_period"></a> [fire\_hose\_index\_rotation\_period](#input\_fire\_hose\_index\_rotation\_period) | The Elasticsearch index rotation period. Index rotation appends a timestamp to the IndexName to facilitate expiration of old data. | `string` | `"OneDay"` | no |
 | <a name="input_hosted_zone_id"></a> [hosted\_zone\_id](#input\_hosted\_zone\_id) | Id of hosted zone in Route53 | `string` | `null` | no |
+| <a name="input_lambda_build_in_docker"></a> [lambda\_build\_in\_docker](#input\_lambda\_build\_in\_docker) | Determines whether or not to build certbot lambda function in docker. | `bool` | `true` | no |
 | <a name="input_lets_encrypt_email"></a> [lets\_encrypt\_email](#input\_lets\_encrypt\_email) | Email to associate with let's encrypt certificate | `string` | n/a | yes |
 | <a name="input_opensearch_ebs_volume_size"></a> [opensearch\_ebs\_volume\_size](#input\_opensearch\_ebs\_volume\_size) | Size of EBS volume to back Open Search domain | `string` | `"10"` | no |
 | <a name="input_opensearch_ebs_volume_type"></a> [opensearch\_ebs\_volume\_type](#input\_opensearch\_ebs\_volume\_type) | Type of EBS volume to back Open Search domain | `string` | `"gp2"` | no |

--- a/main.tf
+++ b/main.tf
@@ -518,6 +518,7 @@ module "test_controller_service" {
   uhs_seed_generator_job_name               = module.uhs_seed_generator[0].job_name
   uhs_seed_generator_job_definiton_arn      = module.uhs_seed_generator[0].job_definiton_arn
   uhs_seed_generator_job_queue_arn          = module.uhs_seed_generator[0].job_queue_arn
+  certbot_lambda_build_in_docker            = var.lambda_build_in_docker
 
   # Tags
   tags = local.tags

--- a/modules/test-controller/README.md
+++ b/modules/test-controller/README.md
@@ -68,6 +68,7 @@ No requirements.
 | <a name="input_azs"></a> [azs](#input\_azs) | A list of availability zones inside the VPC | `list(string)` | `[]` | no |
 | <a name="input_binaries_s3_bucket"></a> [binaries\_s3\_bucket](#input\_binaries\_s3\_bucket) | The S3 bukcet where binaries is stored. | `string` | n/a | yes |
 | <a name="input_binaries_s3_bucket_arn"></a> [binaries\_s3\_bucket\_arn](#input\_binaries\_s3\_bucket\_arn) | The S3 bucket arn where binaries are stored. | `string` | n/a | yes |
+| <a name="input_certbot_lambda_build_in_docker"></a> [certbot\_lambda\_build\_in\_docker](#input\_certbot\_lambda\_build\_in\_docker) | Determines whether or not to build certbot lambda function in docker. | `bool` | `true` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | The ECS cluster ID | `string` | n/a | yes |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | The ECS task CPU | `string` | n/a | yes |
 | <a name="input_create_certbot_lambda"></a> [create\_certbot\_lambda](#input\_create\_certbot\_lambda) | Boolean to create the certbot lambda to update the letsencrypt cert for the test controller. | `bool` | n/a | yes |

--- a/modules/test-controller/main.tf
+++ b/modules/test-controller/main.tf
@@ -727,7 +727,7 @@ module "certbot_lambda" {
   runtime       = "python3.8"
   timeout       = 120
 
-  build_in_docker = true
+  build_in_docker = var.certbot_lambda_build_in_docker
 
   source_path              = "${path.module}/lambda/certbot"
   recreate_missing_package = false

--- a/modules/test-controller/variables.tf
+++ b/modules/test-controller/variables.tf
@@ -133,12 +133,12 @@ variable "uhs_seed_generator_job_name" {
   type = string
   description = "Name of batch job used for uhs seed generation"
 }
-  
+
 variable "uhs_seed_generator_job_definiton_arn" {
   type = string
   description = "Arn of uhs seed generator job definition"
 }
-  
+
 variable "uhs_seed_generator_job_queue_arn" {
   type = string
   description = "Arn of uhs seed generator job queue"
@@ -147,4 +147,10 @@ variable "uhs_seed_generator_job_queue_arn" {
 variable "lets_encrypt_email" {
   type = string
   description = "Email to associate with let's encrypt certificate"
+}
+
+variable "certbot_lambda_build_in_docker" {
+  type        = bool
+  description = "Determines whether or not to build certbot lambda function in docker."
+  default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -159,6 +159,11 @@ variable "create_certbot_lambda" {
   description = "Boolean to create the certbot lambda to update the letsencrypt cert for the test controller."
   default     = true
 }
+variable "lambda_build_in_docker" {
+  type        = bool
+  description = "Determines whether or not to build certbot lambda function in docker."
+  default     = true
+}
 variable "lets_encrypt_email" {
   type = string
   description = "Email to associate with let's encrypt certificate"


### PR DESCRIPTION
Changes lambda builds to optionally build in docker. Previously lambda functions would always be built in docker, but this may be unnecessary in certain cases. Example: running CI jobs in Github actions in a container removes the need to build in docker when the terraform code is already being run in a container.
