### PR TITLE
Add linux-tools-5.15.0-1008-aws package to install perf

### DIFF
--- a/modules/test-controller-agent/templates/init.tpl
+++ b/modules/test-controller-agent/templates/init.tpl
@@ -10,6 +10,7 @@ packages:
   - iproute2
   - linux-tools-common
   - linux-tools-generic
+  - linux-tools-5.15.0-1008-aws
   - linux-tools-5.15.0-1009-aws
   - iperf
   - gdb

--- a/modules/test-controller-agent/templates/init.tpl
+++ b/modules/test-controller-agent/templates/init.tpl
@@ -11,7 +11,6 @@ packages:
   - linux-tools-common
   - linux-tools-generic
   - linux-tools-5.15.0-1008-aws
-  - linux-tools-5.15.0-1009-aws
   - iperf
   - gdb
   - libpcap-dev


### PR DESCRIPTION
This PR:
 - Installs the `linux-tools-5.15.0-1008-aws` package on agent instances to leverage `perf`

Signed-off-by: Kevin Karwaski <kevin.karwaski@gmail.com>