### PR TITLE
[Fix] remove line to copy requirements.txt

### DIFF
--- a/modules/test-controller-deploy/main.tf
+++ b/modules/test-controller-deploy/main.tf
@@ -401,7 +401,6 @@ phases:
       - docker tag agent:latest agent:$CODEBUILD_RESOLVED_SOURCE_VERSION
       - docker container create --name temp agent:latest
       - docker container cp temp:/app/agent ./agent-latest
-      - docker container cp temp:/app/requirements.txt ./requirements.txt
 artifacts:
   files:
     - agent-latest


### PR DESCRIPTION
Fix bug of missing requirements.txt since is not copied from the opencbdc-tctl and is already in the container root, sending it directly through the artifacts