### PR TITLE
Fixing broken reference to ubuntu ami

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ For BYO domains, we recommend using a sub-domain (test.foo.com) as base_domain r
 This module will create several certificates in AWS Certificate Manager which use DNS for validation.
 Be sure that your base domain is updated before you run `terraform apply` or else the certificates will fail to validate.
 
+<br />**Note -** Depending on where your domain is registered, the [certbot lambda](##invoke-the-certbot-lambda) may fail depending on the response from your authoritative DNS server.
+Specifically, if a query for CAA records returns `SERVFAIL` instead of `NOERROR` the lambda will exit with an error as [let's encrypt does not accept this response](https://community.cloudflare.com/t/solved-letsencrypt-dns-servfail-looking-up-caa/302472).
+If you see an error message in the lambda logs along the lines of `Detail: DNS problem: SERVFAIL looking up CAA for <domain-name> - the domain's nameservers may be malfunctioning` this is likely the case.
+To fix this you can add a CAA record under the subdomain in route53.
+The record should be formatted like `<sub-domain-name> CAA 0 issue letsencrypt.org`.
+
 
 ## BYO Network
 This module includes all the necessary networking resources for the test controller to communicate with agents across three regions.

--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -61,12 +61,21 @@ resource "aws_key_pair" "bastion" {
 
 # Lookup ubuntu AMI ID
 data "aws_ami" "bastion" {
+
+  most_recent = true
+
   owners = ["099720109477"] # Canonical (Ubuntu)
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210129"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
   }
+
+  filter {
+    name = "virtualization-type"
+    values = ["hvm"]
+  }
+
 }
 
 # Elastic IP to assign to bastion host


### PR DESCRIPTION
This still results in a warning "Starting March 30, 2023, AWS CodeBuild will be moving these images to an unsupported status and they will not be cached on the build hosts anymore.", however, at least the build doesn't break.

Subsequent issue should be to use a different version, test, and update. 